### PR TITLE
Build launcher that isolates the tool's classpath from the Quarkus augmentor's classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+#Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+.flattened-pom.xml
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# NetBeans
+nb-configuration.xml
+
+# Visual Studio Code
+.vscode
+.factorypath
+
+# OSX
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Local environment
+.env

--- a/src/main/java/org/acme/Constants.java
+++ b/src/main/java/org/acme/Constants.java
@@ -1,0 +1,14 @@
+package org.acme;
+
+public interface Constants {
+
+    String KEYCLOAK_VERSION = "19.0.1"; // 999-SNAPSHOT to test the current main branch
+    String ORG_KEYCLOAK = "org.keycloak";
+    String KEYCLOAK_QUARKUS_SERVER = "keycloak-quarkus-server";
+
+    String KEYCLOAK_QUARKUS_DIST = "keycloak-quarkus-dist";
+    String IO_QUARKUS = "io.quarkus";
+    String QUARKUS_JDBC_PREFIX = "quarkus-jdbc-";
+    String DATABASE="dev-file";
+
+}

--- a/src/main/java/org/acme/Launcher.java
+++ b/src/main/java/org/acme/Launcher.java
@@ -1,0 +1,59 @@
+package org.acme;
+
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class Launcher {
+
+	public static void main(String[] args) throws Exception {
+		
+		final MavenArtifactResolver resolver = MavenArtifactResolver.builder().setWorkspaceDiscovery(false).build();
+		final DependencyNode root = resolver.getSystem().resolveDependencies(resolver.getSession(), new DependencyRequest().setCollectRequest(
+				new CollectRequest().setRootArtifact(new DefaultArtifact(Constants.ORG_KEYCLOAK, "keycloak-build-launcher", "jar", "1.0"))
+				.addDependency(new Dependency(new DefaultArtifact(Constants.IO_QUARKUS, "quarkus-bootstrap-core", "jar", "999-SNAPSHOT"), JavaScopes.RUNTIME))
+				.addDependency(new Dependency(new DefaultArtifact(Constants.IO_QUARKUS, "quarkus-bootstrap-maven-resolver", "jar", "999-SNAPSHOT"), JavaScopes.RUNTIME))))
+		.getRoot();
+		final List<URL> launcherUrls = new ArrayList<>();
+		collectUrls(root, launcherUrls);
+		launcherUrls.add(Launcher.class.getProtectionDomain().getCodeSource().getLocation());
+		
+		final ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+		try(URLClassLoader launcherCl = new URLClassLoader(launcherUrls.toArray(new URL[0]), originalCl.getParent())) {
+			Thread.currentThread().setContextClassLoader(launcherCl);
+			Method keycloakBuilder = launcherCl.loadClass("org.acme.Keycloak").getMethod("main", Map.class);
+			keycloakBuilder.invoke(null, Map.of());
+		} finally {
+			Thread.currentThread().setContextClassLoader(originalCl);
+		}
+	}
+	
+	private static void collectUrls(DependencyNode node, List<URL> urls) {
+		if(node.getArtifact() != null && node.getArtifact().getFile() != null) {
+			try {
+				urls.add(node.getArtifact().getFile().toURI().toURL());
+			} catch (MalformedURLException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+		for(DependencyNode c : node.getChildren()) {
+			collectUrls(c, urls);
+		}
+	}
+}

--- a/src/main/resources/keycloak/application.properties
+++ b/src/main/resources/keycloak/application.properties
@@ -1,5 +1,7 @@
 # Inherit all configuration from the default runtime settings and sets those specific to the distribution
 
 quarkus.package.output-name=keycloak
-quarkus.package.type=uberjar
+quarkus.package.type=mutable-jar
+quarkus.package.output-directory=lib
+quarkus.package.user-providers-directory=../providers
 quarkus.package.main-class=keycloak


### PR DESCRIPTION
This fixes the classloading issue with the `quarkus-picocli` dependency.

There is still some work to do in this regard to pre-package the necessary launcher dependencies in the tool's package.