### PR TITLE
Adding ci.yml for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+   # as the ci.yml contains actions that are required for PRs to be merged, it will always need to run on all PRs
+  pull_request: {}
+
+jobs:
+  build:
+    name: Keycloak Builder
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build Keycloak Builder
+      run: mvn -B -e clean verify --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
             <dependency>
               <artifactId>quarkus-ide-config</artifactId>
               <groupId>io.quarkus</groupId>
-              <version>999-SNAPSHOT</version>
+              <version>${quarkus.platform.version}</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
Finishes #4 
- Adds ci.yml for Github Actions to be run for every PR
- Correcting the version of quarkus-ide-config dependancy for. ci.yml to work.