### PR TITLE
Map Keycloak's 'postgres' to Quarkus' 'postgresql'

### DIFF
--- a/src/main/java/io/keycloak/builder/Constants.java
+++ b/src/main/java/io/keycloak/builder/Constants.java
@@ -14,7 +14,7 @@ public interface Constants {
     String IO_QUARKUS = "io.quarkus";
     String QUARKUS_BOOTSTRAP_VERSION = "2.13.3.Final"; // this should be removed once Keycloak moves to 2.13
     String QUARKUS_JDBC_PREFIX = "quarkus-jdbc-";
-    String DATABASE = "dev-file";
+    String DEFAULT_DATABASE = "dev-file";
 
     String OPTION_CACHE = "--cache";
     String OPTION_DB = "--db";


### PR DESCRIPTION
While Keycloak accepts `postgres` as a value of `--db` for PostgreSQL, Quarkus uses `postgresql` in its extension name. This PR maps Keycloak's `postgres` to `postgresql` for Quarkus.